### PR TITLE
Wrong link to autopublish

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ server.
 
 Remember that `senaite.autopublish` depends on `senaite.queue` and the latter
 has to be properly configured too. Please, check the usage and configuration
-instructions provided in `senaite.queue repository <https://github.com/senaite/senaite.queue`_.
+instructions provided in `senaite.queue repository <https://github.com/senaite/senaite.queue>`_.
 
 Screenshots
 ===========


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.autopublish/issues/

## Current behavior before PR

## Desired behavior after PR is merged

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
